### PR TITLE
Workaround for Content-Security-Policy is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Setters and getters are compiled to functions and cached for Performance™
 
     console.log(getBaz(obj)) // => 'found me!'
     setBaz(obj, 'set me!')
-    console.log(foo.bar[1].buz.baz) // => 'set me!'
+    console.log(obj.foo.bar[1].buz.baz) // => 'set me!'
 
 ### `getter(expression, [ safeAccess ])`
 
@@ -37,7 +37,7 @@ returns a function that accepts an obj and a value and sets the property pointed
 
 ### `expr(expression, [ safeAccess], [ paramName = 'data'])`
 
-Returns a normalized expression string pointing to a property on root object 
+Returns a normalized expression string pointing to a property on root object
 `paramName`.
 
     expr.expr("foo['bar'][0].baz", true, 'obj') // => "(((obj.foo || {})['bar'] || {})[0])"

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Setters and getters are compiled to functions and cached for Performance™
 
 ### `getter(expression, [ safeAccess ])`
 
-returns a function that accepts an obj and returns the value at the supplied expression. You can create a "safe" getter, which won't error out when accessing properties that don't exist, reducing existance checks befroe property access:
+Returns a function that accepts an obj and returns the value at the supplied expression. You can create a "safe" getter, which won't error out when accessing properties that don't exist, reducing existance checks befroe property access:
 
     expr.getter('foo.bar.baz', true)({ foo: {} }) // => undefined
     //instead of val = foo.bar && foo.bar.baz
 
 ### `setter(expression)`
 
-returns a function that accepts an obj and a value and sets the property pointed to by the expression to the supplied value.
+Returns a function that accepts an obj and a value and sets the property pointed to by the expression to the supplied value.
 
 
 ### `expr(expression, [ safeAccess], [ paramName = 'data'])`
@@ -47,17 +47,39 @@ Returns a normalized expression string pointing to a property on root object
 Returns an array of each path segment.
 
 ```js
- split("foo['bar'][0].baz") // [ "foo", "'bar'", "0", "baz"]
+expr.split("foo['bar'][0].baz") // [ "foo", "'bar'", "0", "baz"]
 ```
 
-### `forEach(path, iterator[, thisArg]) `
+### `forEach(path, iterator[, thisArg])`
 
 Iterate through a path but segment, with some additional helpful metadata about the segment. The iterator function is called with: `pathSegment`, `isBracket`, `isArray`, `idx`, `segments`
 
 ```js
-.forEach('foo["bar"][1]', function(pathSegment, isBracket, isArray, idx, segments) {
+expr.forEach('foo["bar"][1]', function(pathSegment, isBracket, isArray, idx, segments) {
   // 'foo'   -> isBracket = false, isArray = false, idx = 0
   // '"bar"' -> isBracket = true,  isArray = false, idx = 1
   // '0'     -> isBracket = false, isArray = true,  idx = 2
-}
+})
+```
+
+### `normalizePath(path)`
+
+Returns an array of path segments without quotes and spaces.
+```js
+expr.normalizePath('foo["bar"][ "1" ][2][ " sss " ]')
+// ['foo', 'bar', '1', '2', ' sss ']
+```
+
+### `new Cache(maxSize)`
+
+Just an utility class, returns an instance of cache. When the max size is exceeded, cache clears its storage.
+```js
+var cache = new Cache(2)
+cache.set('a', 123) // returns 123
+cache.get('a') // returns 123
+cache.clear()
+
+cache.set('a', 1)
+cache.set('b', 2) // cache contains 2 values
+cache.set('c', 3) // cache was cleaned automatically and contains 1 value
 ```

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ obj = {
   }
 };
 
-//--- Getters -----------------------------------------------
+// -- Getters --
 a.strictEqual(getter('foo.fux')(obj), 5);
 a.deepEqual(getter('foo.bar')(obj), ['baz', 'bux']);
 
@@ -22,7 +22,7 @@ a.strictEqual(getter('foo.bar[1]')(obj), 'bux');
 a.strictEqual(getter('["foo"]["bar"][1]')(obj), 'bux');
 a.strictEqual(getter('[1]')([1, 'bux']), 'bux');
 
-//safe access
+// safe access
 a.strictEqual(getter('foo.fux', true)(obj), 5);
 a.deepEqual(getter('foo.bar', true)(obj), ['baz', 'bux']);
 
@@ -40,7 +40,7 @@ a.strictEqual(getter('foo.N40000002S5U0', true)(obj), 2);
 a.strictEqual(getter('foo["FE43-D880-21AE"]', true)(obj), 3);
 a.strictEqual(getter('foo.FE43-D880-21AE', true)(obj), 3);
 
-//--- Setters -----------------------------------------------
+// -- Setters --
 setter('foo.fux')(obj, 10);
 a.strictEqual(obj.foo.fux, 10);
 
@@ -50,13 +50,32 @@ a.strictEqual(obj.foo.bar[1], 'bot');
 setter('[\'foo\']["bar"][1]')(obj, 'baz');
 a.strictEqual(obj.foo.bar[1], 'baz');
 
-// -- Split -------
+// -- Cache --
+var cache = new expression.Cache(3)
+a.strictEqual(cache._size, 0)
+a.strictEqual(cache.set('a', a), a)
+a.strictEqual(cache.get('a'), a)
+a.strictEqual(cache._size, 1)
+a.strictEqual(cache.set('b', 123), 123)
+a.strictEqual(cache.get('b'), 123)
+a.strictEqual(cache.set('b', 321), 321)
+a.strictEqual(cache.get('b'), 321)
+a.strictEqual(cache.set('c', null), null)
+a.strictEqual(cache.get('c'), null)
+a.strictEqual(cache._size, 3)
+a.strictEqual(cache.set('d', 444), 444)
+a.strictEqual(cache._size, 1)
+cache.clear()
+a.strictEqual(cache._size, 0)
+a.strictEqual(cache.get('a'), undefined)
+
+// -- split --
 
 var parts = expression.split('foo.baz["bar"][1]');
 
 a.strictEqual(parts.length, 4);
 
-// -- JOIN -------
+// -- join --
 
 var parts = expression.split('foo.baz["bar"][1]');
 
@@ -64,7 +83,7 @@ a.strictEqual(expression.join(['0', 'baz', '"bar"', 1]), '[0].baz["bar"][1]');
 
 a.strictEqual(expression.join(parts), 'foo.baz["bar"][1]');
 
-// -- ForEach ------
+// -- forEach --
 
 var count = 0;
 
@@ -101,4 +120,12 @@ expression.forEach('foo.baz["bar"][1]', function(
 });
 
 a.strictEqual(count, 3);
+
+// -- normalizePath --
+
+a.deepEqual(
+  expression.normalizePath('foo[ " bux\'s " ].bar["baz"][ 9 ][ \' s \' ]'),
+  ['foo', ' bux\'s ', 'bar', 'baz', '9', ' s ']
+)
+
 console.log('--- Tests Passed ---');


### PR DESCRIPTION
If `Content-Security-Policy` blocks creation new function from a string, then fallback methods are used. They are slower, but at least works well. Path splitting process is caching to the limited-size-object by analogy with `lo-dash` library.

This PR is related to the issue https://github.com/jquense/expr/issues/1