### PR TITLE
fix getterFallback safe check condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function getterFallback(parts, safe, data) {
   var index = 0,
     len = parts.length
   while (index < len) {
-    if (data == null || !safe) {
+    if (data != null || !safe) {
       data = data[parts[index++]]
     } else {
       return


### PR DESCRIPTION
Like i said in #1  when you were in the situation were the contentSecurityPolicy variable was set to true, yup validation was failing.

It's due to the check on line 112 wich was `data == null || !safe`, that's wrong and should be `data != null || !safe` wich has the correct behaviour

Maybe we should add a test on contentSecurityPolicy = true 