### PR TITLE
Added setConfig function to switch to the slower CSP safe implementat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 
+# IntelliJ
+.idea
+
 # =========================
 # Operating System Files
 # =========================
@@ -26,7 +29,8 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must ends with two \r.
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/README.md
+++ b/README.md
@@ -83,3 +83,25 @@ cache.set('a', 1)
 cache.set('b', 2) // cache contains 2 values
 cache.set('c', 3) // cache was cleaned automatically and contains 1 value
 ```
+
+
+### CSP 
+
+The default implementation of this package depends on `new Function`. If your Content Security Policy prevents the use 
+`eval`, a (slower) fallback implementation will be used instead. 
+
+This library will try to evaluate a test `new Function` 
+statement in a `try`/`catch` block. If it succeeds, `eval` is allowed a the faster implementation will be used. If it 
+fails the slower fallback implementation will be used.
+
+If you have a CSP policy which blocks `eval` in place this test will send a violation event to your `report-uri` on 
+every page load. You can prevent this check from being executed and force the fallback implementation by means of the 
+following configuration code: 
+
+```
+setConfig({
+  contentSecurityPolicy: true
+})
+```
+
+Make sure you execute this configuration before any other Yup/Expr related code.  

--- a/README.md
+++ b/README.md
@@ -88,11 +88,10 @@ cache.set('c', 3) // cache was cleaned automatically and contains 1 value
 ### CSP 
 
 The default implementation of this package depends on `new Function`. If your Content Security Policy prevents the use 
-`eval`, a (slower) fallback implementation will be used instead. 
+of `eval`, a (slower) fallback implementation will be used instead. 
 
-This library will try to evaluate a test `new Function` 
-statement in a `try`/`catch` block. If it succeeds, `eval` is allowed a the faster implementation will be used. If it 
-fails the slower fallback implementation will be used.
+This library will try to evaluate the `new Function` statement in a `try`/`catch` block. If it succeeds, `eval` 
+is allowed and the faster implementation will be used. If it fails the slower fallback implementation will be used.
 
 If you have a CSP policy which blocks `eval` in place this test will send a violation event to your `report-uri` on 
 every page load. You can prevent this check from being executed and force the fallback implementation by means of the 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "property-expr",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "property-expr",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "tiny util for getting and setting deep object props safely",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "property-expr",
-  "version": "1.5.2",
+  "version": "1.5.1",
   "description": "tiny util for getting and setting deep object props safely",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@jquense An alternative to https://github.com/jquense/expr/pull/10. In our project we use a CSP policy which prevents the use of `eval` (`new Function` for example). The current implementation triggers a violation event because it will try if `new Function` in a `try/catch` block. This results in a call to our CSP report endpoint on every page load. 

In this PR I made it possible to opt-out of the (faster) `new Function` implementation. Using the following code one can switch to the slower, but CSP safe-code, without the executing the `try/catch` test. 

```
setConfig({
  contentSecurityPolicy: true
})
```