### PR TITLE
Allow setter (not on legacy compiler) to create if expression doesn't fully exist

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ interface Expr {
   }
 
   split(path: string): string[]
-  setter(path: string): (data: any, value: any) => any
+  setter(path: string, options?: {create: boolean, array: boolean}): (data: any, value: any) => any
   getter(path: string): (data: any) => any
   join(segments: string[]): string
   forEach(

--- a/index.js
+++ b/index.js
@@ -41,17 +41,21 @@ module.exports = {
 
   normalizePath: normalizePath,
 
-  setter: function(path) {
+  setter: function(path, options) {
     var parts = normalizePath(path)
-
+    let { create = false, array = true } = options || {};
+    let cacheKey = path+''+create+''+array;
     return (
-      setCache.get(path) ||
-      setCache.set(path, function setter(data, value) {
+      setCache.get(cacheKey) ||
+      setCache.set(cacheKey, function setter(data, value) {
         var index = 0,
-          len = parts.length
+          len = parts.length;
         while (index < len - 1) {
-          data = data[parts[index++]]
+          var next = data[parts[index]];
+          if(!next && create) data[parts[index]] = parts[index+1].match(DIGIT_REGEX) && array ? [] : {};
+          data = data[parts[index++]];
         }
+
         data[parts[index]] = value
       })
     )

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ const a = require('assert')
 const expr = require('./index')
 const compiler = require('./compiler')
 
-function runSetterGetterTests({ setter, getter }) {
+function runSetterGetterTests({ setter, getter }, skipCreate) {
   let obj = {
     foo: {
       bar: ['baz', 'bux'],
@@ -48,6 +48,23 @@ function runSetterGetterTests({ setter, getter }) {
 
   setter('[\'foo\']["bar"][1]')(obj, 'baz')
   a.strictEqual(obj.foo.bar[1], 'baz')
+
+  // -- Create Setters --
+  if(!skipCreate) {
+    a.throws(() => setter('bar.foo')(obj,10));
+    setter('bar.foo',{create:true})(obj,10);
+    a.strictEqual(obj.bar.foo,10);
+    
+    setter('bar.quz[2]',{create:true,array:false})(obj,'baz');
+    a.ok(!Array.isArray(obj.bar.quz));
+    a.strictEqual(obj.bar.quz['2'],'baz');
+  
+    setter('bar.qux[2]',{create:true})(obj,'baz');
+    a.ok(Array.isArray(obj.bar.qux));
+    a.ok(obj.bar.qux.length === 3);
+    a.strictEqual(obj.bar.qux[2],'baz');
+  }
+
 }
 
 console.log('--- Test Start ---')
@@ -126,6 +143,6 @@ a.deepEqual(
 )
 
 runSetterGetterTests(expr)
-runSetterGetterTests(compiler)
+runSetterGetterTests(compiler,true)
 
 console.log('--- Tests Passed ---')


### PR DESCRIPTION
I frequently use this package (specifically `getter`) together with [flat](https://www.npmjs.com/package/flat) (specifically for the `unflatten` function). I think it would be neat if that functionality to create a value if any part of the expression doesn't exist existed in this library (selfishly so I could remove flat and solely rely on this library).

This is a first crack at it, I'm expecting there's probably edge cases that I'm missing. 

Works like:

```js
const obj = {};
setter('path[1]')(obj,'val); // throws error
setter('path[1]', { create: true } )(obj, 'val'); // { path: [undefined, 'val' ] }
setter('path[1]', { create: true, array: false} )(obj, 'val'); // { path: { 1: 'val' } }
```

Thanks for the awesome library!