### PR TITLE
Make index.d.ts export correct

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,4 +28,4 @@ export interface Expr {
 }
 
 declare const expr: Expr
-export = expr
+export default expr


### PR DESCRIPTION
The JS exports a complete object on module.exports, it does not export different variables. The only reason this definition worked was compatibility hacks.